### PR TITLE
fix 'java.io.FileNotFoundException: Could not locate cemerick/pomegranat...

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 #!/usr/bin/env boot
 
-#tailrecursion.boot.core/version "2.2.1"
+#tailrecursion.boot.core/version "2.3.1"
 
 (set-env!
   :dependencies (read-string (slurp "deps.edn"))

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-[[tailrecursion/boot.task   "2.1.1"]
+[[tailrecursion/boot.task   "2.1.2"]
  [tailrecursion/hoplon      "5.5.0"]
  [tailrecursion/boot.notify "2.0.0-SNAPSHOT"]
  [tailrecursion/boot.ring   "0.1.0-SNAPSHOT"]


### PR DESCRIPTION
When running `boot gleam-app` I get:

```
java.io.FileNotFoundException: Could not locate cemerick/pomegranate__init.class or cemerick/pomegranate.clj on classpath:
 at clojure.lang.RT.load (RT.java:443)
    clojure.lang.RT.load (RT.java:411)
    clojure.core$load$fn__5018.invoke (core.clj:5530)
    clojure.core$load.doInvoke (core.clj:5529)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$load_one.invoke (core.clj:5336)
    clojure.core$load_lib$fn__4967.invoke (core.clj:5375)
    clojure.core$load_lib.doInvoke (core.clj:5374)
    clojure.lang.RestFn.applyTo (RestFn.java:142)
    clojure.core$apply.invoke (core.clj:619)
    clojure.core$load_libs.doInvoke (core.clj:5413)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:619)
    clojure.core$require.doInvoke (core.clj:5496)
    clojure.lang.RestFn.invoke (RestFn.java:619)
    tailrecursion.boot.core$eval40$loading__4910__auto____41.invoke (core.clj:10)
    tailrecursion.boot.core$eval40.invoke (core.clj:10)
    clojure.lang.Compiler.eval (Compiler.java:6619)
    clojure.lang.Compiler.eval (Compiler.java:6608)
    clojure.lang.Compiler.load (Compiler.java:7064)
    clojure.lang.RT.loadResourceScript (RT.java:370)
    clojure.lang.RT.loadResourceScript (RT.java:361)
    clojure.lang.RT.load (RT.java:440)
    clojure.lang.RT.load (RT.java:411)
    clojure.core$load$fn__5018.invoke (core.clj:5530)
    clojure.core$load.doInvoke (core.clj:5529)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$load_one.invoke (core.clj:5336)
    clojure.core$load_lib$fn__4967.invoke (core.clj:5375)
    clojure.core$load_lib.doInvoke (core.clj:5374)
    clojure.lang.RestFn.applyTo (RestFn.java:142)
    clojure.core$apply.invoke (core.clj:619)
    clojure.core$load_libs.doInvoke (core.clj:5413)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:619)
    clojure.core$require.doInvoke (core.clj:5496)
    clojure.lang.RestFn.invoke (RestFn.java:930)
    tailrecursion.boot$eval3$loading__4910__auto____4.invoke (boot.clj:9)
    tailrecursion.boot$eval3.invoke (boot.clj:9)
    clojure.lang.Compiler.eval (Compiler.java:6619)
    clojure.lang.Compiler.eval (Compiler.java:6608)
    clojure.lang.Compiler.load (Compiler.java:7064)
    clojure.lang.RT.loadResourceScript (RT.java:370)
    clojure.lang.RT.loadResourceScript (RT.java:361)
    clojure.lang.RT.load (RT.java:440)
    clojure.lang.RT.load (RT.java:411)
    clojure.core$load$fn__5018.invoke (core.clj:5530)
    clojure.core$load.doInvoke (core.clj:5529)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$load_one.invoke (core.clj:5336)
    clojure.core$load_lib$fn__4967.invoke (core.clj:5375)
    clojure.core$load_lib.doInvoke (core.clj:5374)
    clojure.lang.RestFn.applyTo (RestFn.java:142)
    clojure.core$apply.invoke (core.clj:619)
    clojure.core$load_libs.doInvoke (core.clj:5413)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invoke (core.clj:619)
    clojure.core$require.doInvoke (core.clj:5496)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    tailrecursion.boot.loader$_main.doInvoke (loader.clj:186)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    tailrecursion.boot.loader.main (:-1)
```

Solution came from here: http://stackoverflow.com/a/22857341/514866
